### PR TITLE
Fix Icon button component press/unpress behavior

### DIFF
--- a/app/components/arara/icon_button_component.rb
+++ b/app/components/arara/icon_button_component.rb
@@ -12,7 +12,9 @@ module Arara
     end
 
     def default_html_class
-      'mdc-icon-button'
+      klasses = ['mdc-icon-button']
+      klasses << ['mdc-icon-button--on'] if pressed
+      klasses
     end
 
     def aria_data


### PR DESCRIPTION
Why?
- Based on a boolean the button may be pressed or unpressed. The option already exists but is not verified to add/skip the MDC button HTML class that makes this behavior;

How?
- Add a verification if the `pressed` option is true, if so we add the `mdc-icon-button--on` on the html classes array