### PR TITLE
Add option for the surface dialog component

### DIFF
--- a/app/components/arara/dialog_component.rb
+++ b/app/components/arara/dialog_component.rb
@@ -21,8 +21,10 @@ module Arara
     end
 
     def surface_options
+      html_class = ["mdc-dialog__surface"]
+      html_class << surface_class if surface_class
       {
-        class: "mdc-dialog__surface #{surface_class}",
+        class: html_class.join(" "),
         role: role,
         aria: {
           modal: "true",

--- a/app/components/arara/dialog_component.rb
+++ b/app/components/arara/dialog_component.rb
@@ -3,15 +3,16 @@ module Arara
     validates :content, presence: true
 
     include Arara::BaseComponent
-    
-    attr_reader :role, :labelledby, :describedby
 
-    def initialize(role: "alertdialog", labelledby:, describedby:, **kw)
+    attr_reader :role, :labelledby, :describedby, :surface_class
+
+    def initialize(role: "alertdialog", labelledby:, describedby:, surface_class: nil, **kw)
       super(tag: "div", role: role, **kw)
 
       @role = role
       @labelledby = labelledby
       @describedby = describedby
+      @surface_class = surface_class
     end
 
 
@@ -20,8 +21,8 @@ module Arara
     end
 
     def surface_options
-      opts = {
-        class: "mdc-dialog__surface",
+      {
+        class: "mdc-dialog__surface #{surface_class}",
         role: role,
         aria: {
           modal: "true",


### PR DESCRIPTION
### WHY
Today we can't pass more class options to dialog component to add on surface dialog component (That's the modal component)

### HOW
- [x] Add a new argument `surface_class` to gather these classes and merge to `surface_options` method